### PR TITLE
fix: use aws helper to login pip

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.configure-pip }}" == "true" ]; then
-          pip config set site.index-url "https://aws:${{ steps.codeartifact-metadata.outputs.codeartifact-token }}@${{ steps.codeartifact-metadata.outputs.codeartifact-repo-url }}simple/"
+          aws codeartifact login --tool pip --domain  ${{ inputs.codeartifact-domain }} --domain-owner ${{ inputs.codeartifact-domain-owner }} --repository  ${{ inputs.codeartifact-repository }}
         fi
         if [ "${{ inputs.configure-poetry }}" == "true" ]; then
           poetry config repositories.${{ inputs.codeartifact-repository }} ${{ steps.codeartifact-metadata.outputs.codeartifact-repo-url }}


### PR DESCRIPTION
The previous command did not produce a valid url, breaking builds that rely on `pip` to obtain packages (eg when running `pre-commit` in CI). 

Tested this solution [here](https://github.com/source-ag/cultivate-models/actions/runs/6861675776/job/18657821682?pr=38), seems to work!