### PR TITLE
configure uv

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: Configure Poetry with temporary CodeArtifact credentials
     required: false
     default: "false"
+  configure-uv:
+    description: Configure uv with temporary CodeArtifact credentials
+    required: false
+    default: "false"
 outputs:
   codeartifact-token:
     description: "Temporary token to authenticate with AWS CodeArtifact repositories"
@@ -62,13 +66,23 @@ runs:
         if [ -n "${{ inputs.codeartifact-repository }}" ]; then
           echo "codeartifact-repo-url=$(aws codeartifact get-repository-endpoint --domain ${{ inputs.codeartifact-domain }} --domain-owner ${{ inputs.codeartifact-domain-owner }} --repository ${{ inputs.codeartifact-repository }} --format pypi --query repositoryEndpoint --output text)" >> $GITHUB_OUTPUT
         fi
-    - name: Configure package managers
+        
+    - name: Configure pip
       shell: bash
+      if: ${{ inputs.configure-pip == 'true' }}
+      run: aws codeartifact login --tool pip --domain  ${{ inputs.codeartifact-domain }} --domain-owner ${{ inputs.codeartifact-domain-owner }} --repository  ${{ inputs.codeartifact-repository }}
+
+    - name: Configure poetry
+      shell: bash
+      if: ${{ inputs.configure-poetry == 'true' }}
       run: |
-        if [ "${{ inputs.configure-pip }}" == "true" ]; then
-          aws codeartifact login --tool pip --domain  ${{ inputs.codeartifact-domain }} --domain-owner ${{ inputs.codeartifact-domain-owner }} --repository  ${{ inputs.codeartifact-repository }}
-        fi
-        if [ "${{ inputs.configure-poetry }}" == "true" ]; then
           poetry config repositories.${{ inputs.codeartifact-repository }} ${{ steps.codeartifact-metadata.outputs.codeartifact-repo-url }}
           poetry config http-basic.${{ inputs.codeartifact-repository }} aws ${{ steps.codeartifact-metadata.outputs.codeartifact-token }}
-        fi
+
+    - name: Configure uv
+      shell: bash
+      if: ${{ inputs.configure-uv == 'true' }}
+      run: |
+          TOKEN=${{ steps.codeartifact-metadata.outputs.codeartifact-token }}
+          URL=$(echo ${{ steps.codeartifact-metadata.outputs.codeartifact-repo-url }} | sed 's/^https:\/\///')
+          echo "UV_EXTRA_INDEX_URL=https://aws:${TOKEN}@${URL}simple" >> $GITHUB_ENV


### PR DESCRIPTION
Successful run: https://github.com/source-ag/science-research/actions/runs/10927311769/job/30333174314

I thought it would be more readable to use separate steps for each tool now that we have 3 steps. That requires equally clunky evaluation of the input value because each input field is a string. I vaguely remember Remmelt having a lot of fun with this problem a long time ago.
https://github.com/actions/runner/issues/1483#issuecomment-994747723